### PR TITLE
Update uuid to version 3.0.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -19,8 +19,8 @@
     "LICENSE",
     "package.json"
   ],
-  "engines" : {
-    "node" : ">=6.0"
+  "engines": {
+    "node": ">=6.0"
   },
   "dependencies": {
     "body-parser": "^1.14.2",
@@ -29,8 +29,8 @@
     "http-status": "^0.2.0",
     "nock": "^8.0.0",
     "node-fetch": "^1.3.3",
-    "node-uuid": "^1.4.7",
-    "q": "^1.4.1"
+    "q": "^1.4.1",
+    "uuid": "^3.0.0"
   },
   "devDependencies": {
     "@types/body-parser": "0.0.33",
@@ -42,7 +42,6 @@
     "@types/nock": "^8.0.33",
     "@types/node-uuid": "0.0.28",
     "@types/q": "0.0.32",
-    "@types/http-status": "^0.2.29",
     "chai": "^3.4.1",
     "chai-as-promised": "^5.1.0",
     "express": "^4.13.3",

--- a/src/mock-tooling/index.ts
+++ b/src/mock-tooling/index.ts
@@ -1,6 +1,6 @@
 import * as HttpStatus from 'http-status';
 import * as nock from 'nock';
-import * as uuid from 'node-uuid';
+import * as uuid from 'uuid';
 import * as url from 'url';
 
 let tokens = [];


### PR DESCRIPTION
## Version 3.0.0 of [uuid](https://github.com/kelektiv/node-uuid) just got published.

Hi there,

This week a new version of the [uuid](https://github.com/kelektiv/node-uuid) module got released. The old module which was available by the name [node-uuid](https://www.npmjs.com/package/node-uuid) got deprecated and will show error message upon every install of the module.

To get rid of those install errors I've created this **automated pull request**. I've run some checks against your code base to test whether you're using one of the [deprecated apis](https://github.com/kelektiv/node-uuid/commit/5ae7287fc935eb55ef39133e4be17ef623ca000e), but this isn't the case.


Please test the changes against your code. I didn't run any tests and therefore can't guarantee that it isn't breaking. You can also just close this pr if you don't want to update your module.

In case there's already another pr open to upgrade uuid, I'm sorry for the effort I'm causing.