### PR TITLE
feat(open-source): become zalando-independent

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,27 +15,29 @@ See [STUPS documentation](http://stups.readthedocs.org/en/latest/user-guide/acce
 ## Migrating to 2.x.x
 
 If you depend on the `realm` property you now have to pass the value via the `queryParams` parameters in `OAuthConfig`:
+
 ```typescript
 // will NOT work anymore:
 getAccessToken({
   // all the other config
   // ...
   realm: EMPLOYEES_REALM,
-  })
-  .then(token => {
-    // ...
-  });
+})
+.then(token => {
+  // ...
+});
 
 // instead use this:
 getAccessToken({
   // all the other config
   // ...
   queryParams: { realm: '/employees' }
-  })
-  .then(token => {
-    // ...
-  });
+})
+.then(token => {
+  // ...
+});
 ```
+
 See the [changelog](#changelog) for more information.
 
 ## Usage
@@ -226,9 +228,11 @@ cleanMock();
 ## Changelog
 
 #### `2.0.0` - **BREAKING**
+
 The (zalando-specific) `realm` property was removed from `OAuthConfig`. Also, the corresponding constants (`SERVICES_REALM` and `EMPLYEES_REALM`) were removed. Instead, you can add the realm (and arbitrary other query parameters) via the `queryParams` property in `OAuthConfig`.
 
 #### `1.0.0` - **BREAKING**
+
 The signature of `requireScopesMiddleware` is now incompatible with previous versions, `precedenceFunction?` is now part of `precedenceOptions?`.
 
 ## License

--- a/README.md
+++ b/README.md
@@ -12,6 +12,32 @@ Currently the following flows are supported:
 See [STUPS documentation](http://stups.readthedocs.org/en/latest/user-guide/access-control.html#implementing-a-client-asking-resource-owners-for-permission) and [OAuth2 documentation](https://tools.ietf.org/html/rfc6749) for more information.
 
 
+## Migrating to 2.x.x
+
+If you depend on the `realm` property you now have to pass the value via the `queryParams` parameters in `OAuthConfig`:
+```typescript
+// will NOT work anymore:
+getAccessToken({
+  // all the other config
+  // ...
+  realm: EMPLOYEES_REALM,
+  })
+  .then(token => {
+    // ...
+  });
+
+// instead use this:
+getAccessToken({
+  // all the other config
+  // ...
+  queryParams: { realm: '/employees' }
+  })
+  .then(token => {
+    // ...
+  });
+```
+See the [changelog](#changelog) for more information.
+
 ## Usage
 
 Note: `node >= 6.0.0` required to consume this library.
@@ -51,7 +77,6 @@ tokenCache.get('service-foo')
 * `grantType` string (`AUTHORIZATION_CODE_GRANT` | `PASSWORD_CREDENTIALS_GRANT`)
 * `accessTokenEndpoint` string
 * `tokenInfoEndpoint` string - mandatory for TokenCache
-* `realm` string (`SERVICES_REALM` | `EMPLOYEES_REALM`)
 * `scopes` string optional
 * `queryParams` {} optional
 * `redirect_uri` string optional (required with `AUTHORIZATION_CODE_GRANT`)
@@ -117,7 +142,6 @@ getAccessToken(options)
 * `credentialsDir` string
 * `grantType` string (`AUTHORIZATION_CODE_GRANT` | `PASSWORD_CREDENTIALS_GRANT` | `REFRESH_TOKEN_GRANT`)
 * `accessTokenEndpoint` string
-* `realm` string (`SERVICES_REALM` | `EMPLOYEES_REALM`)
 * `scopes` string optional
 * `queryParams` {} optional
 * `redirect_uri` string optional (required with `AUTHORIZATION_CODE_GRANT`)
@@ -135,15 +159,6 @@ String constant specifying the Resource Owner Password Credentials Grant type.
 #### REFRESH_TOKEN_GRANT
 
 String constant specifying the Refresh Token Grant type.
-
-#### SERVICES_REALM
-
-String constant specifying the services realm.
-
-#### EMPLOYEES_REALM
-
-String constant specifying the employees realm.
-
 
 ## Mock tooling
 
@@ -210,7 +225,11 @@ cleanMock();
 
 ## Changelog
 
-`1.0.0` - **BREAKING** The signatur of requireScopesMiddleware is now incompatible with previous versions, `precedenceFunction?` is now part of `precedenceOptions?`.
+#### `2.0.0` - **BREAKING**
+The (zalando-specific) `realm` property was removed from `OAuthConfig`. Also, the corresponding constants (`SERVICES_REALM` and `EMPLYEES_REALM`) were removed. Instead, you can add the realm (and arbitrary other query parameters) via the `queryParams` property in `OAuthConfig`.
+
+#### `1.0.0` - **BREAKING**
+The signature of `requireScopesMiddleware` is now incompatible with previous versions, `precedenceFunction?` is now part of `precedenceOptions?`.
 
 ## License
 

--- a/integration-test/mock-tooling/index.ts
+++ b/integration-test/mock-tooling/index.ts
@@ -4,12 +4,12 @@ import * as chaiAsPromised from 'chai-as-promised';
 import {
   getTokenInfo,
   getAccessToken,
-  SERVICES_REALM,
   PASSWORD_CREDENTIALS_GRANT,
   mockTokeninfoEndpoint,
   mockAccessTokenEndpoint,
   cleanMock
 } from '../../src/index';
+
 import { TokenInfo } from '../../src/types/TokenInfo';
 import { Token } from '../../src/types/Token';
 
@@ -51,7 +51,6 @@ describe('mock tooling', () => {
       // given
       const validAuthToken = {
         'expires_in': 3600,
-        'realm': 'services',
         'scope': ['uid'],
         'access_token': 'foo'
       };
@@ -73,7 +72,6 @@ describe('mock tooling', () => {
       // given
       const validAuthToken = {
         'expires_in': 3600,
-        'realm': 'services',
         'scope': ['uid'],
         'access_token': 'foo'
       };
@@ -110,7 +108,6 @@ describe('mock tooling', () => {
       // given
       const validAuthToken = {
         'expires_in': 3600,
-        'realm': 'services',
         'scope': ['uid'],
         'access_token': 'foo'
       };
@@ -154,7 +151,6 @@ describe('mock tooling', () => {
 
       // given
       const options = {
-        realm: SERVICES_REALM,
         scopes: ['uid'],
         accessTokenEndpoint: accessTokenEndpoint,
         credentialsDir: 'integration-test/data/credentials',

--- a/integration-test/oauth-tooling/getAccessToken.spec.ts
+++ b/integration-test/oauth-tooling/getAccessToken.spec.ts
@@ -10,9 +10,7 @@ import {
   getAccessToken,
   PASSWORD_CREDENTIALS_GRANT,
   AUTHORIZATION_CODE_GRANT,
-  REFRESH_TOKEN_GRANT,
-  SERVICES_REALM,
-  EMPLOYEES_REALM
+  REFRESH_TOKEN_GRANT
 } from '../../src/index';
 import { OAuthConfig } from '../../src/types/OAuthConfig';
 
@@ -83,19 +81,17 @@ describe('getAccessToken', () => {
     nock('http://127.0.0.1:30001/oauth2/')
       .post('/access_token')
       .query({
-        realm: SERVICES_REALM,
-        foo: 'bar'
+        realm: '/services'
       })
       .reply(HttpStatus.OK, responseObject);
 
     //when
     const promise = getAccessToken({
-      realm: SERVICES_REALM,
-      scopes: ['campaing.edit_all', 'campaign.read_all'],
+      scopes: ['campaign.edit_all', 'campaign.read_all'],
       accessTokenEndpoint: 'http://127.0.0.1:30001/oauth2/access_token',
       credentialsDir: 'integration-test/data/credentials',
       grantType: PASSWORD_CREDENTIALS_GRANT,
-      queryParams: { foo: 'bar' }
+      queryParams: { realm: '/services' }
     });
 
     //then
@@ -106,8 +102,7 @@ describe('getAccessToken', () => {
 
     before(() => {
       getAccessTokenOptions = {
-        realm: SERVICES_REALM,
-        scopes: ['campaing.edit_all', 'campaign.read_all'],
+        scopes: ['campaign.edit_all', 'campaign.read_all'],
         accessTokenEndpoint: 'http://127.0.0.1:30001/oauth2/access_token',
         credentialsDir: 'integration-test/data/credentials',
         grantType: PASSWORD_CREDENTIALS_GRANT
@@ -161,8 +156,7 @@ describe('getAccessToken', () => {
 
     before(() => {
       getAccessTokenOptionsAuthorization = {
-        realm: SERVICES_REALM,
-        scopes: ['campaing.edit_all', 'campaign.read_all'],
+        scopes: ['campaign.edit_all', 'campaign.read_all'],
         accessTokenEndpoint: 'http://127.0.0.1:30001/oauth2/access_token',
         credentialsDir: 'integration-test/data/credentials',
         code: 'foo',
@@ -218,8 +212,7 @@ describe('getAccessToken', () => {
       // given
       const host = 'http://127.0.0.1:30001/oauth2';
       const options = {
-        realm: SERVICES_REALM,
-        scopes: ['campaing.edit_all', 'campaign.read_all'],
+        scopes: ['campaign.edit_all', 'campaign.read_all'],
         accessTokenEndpoint: `${host}/access_token`,
         credentialsDir: 'integration-test/data/credentials',
         grantType: AUTHORIZATION_CODE_GRANT,
@@ -230,7 +223,7 @@ describe('getAccessToken', () => {
       const responseObject = { 'access_token': '4b70510f-be1d-4f0f-b4cb-edbca2c79d41' };
 
       nock(host)
-      .post('/access_token?realm=/services', (body: any) => {
+      .post('/access_token', (body: any) => {
 
         if (body.grant_type !== options.grantType) {
           return false;
@@ -267,7 +260,6 @@ describe('getAccessToken', () => {
       // given
       const host = 'http://127.0.0.1:30001/oauth2';
       const options =  {
-        realm: EMPLOYEES_REALM,
         accessTokenEndpoint: `${host}/access_token`,
         credentialsDir: 'integration-test/data/credentials',
         grantType: REFRESH_TOKEN_GRANT,
@@ -277,7 +269,7 @@ describe('getAccessToken', () => {
       const responseObject = { 'access_token': '4b70510f-be1d-4f0f-b4cb-edbca2c79d41' };
 
       nock(host)
-      .post('/access_token?realm=/employees', (body: any) => {
+      .post('/access_token', (body: any) => {
 
         if (body.grant_type !== options.grantType) {
           return false;

--- a/integration-test/oauth-tooling/tokenCache.spec.ts
+++ b/integration-test/oauth-tooling/tokenCache.spec.ts
@@ -5,9 +5,9 @@ import * as nock from 'nock';
 
 import {
   TokenCache,
-  PASSWORD_CREDENTIALS_GRANT,
-  SERVICES_REALM
+  PASSWORD_CREDENTIALS_GRANT
 } from '../../src/index';
+
 import { OAuthConfig } from '../../src/types/OAuthConfig';
 
 chai.use(chaiAsPromised);
@@ -20,7 +20,6 @@ describe('tokenCache', () => {
 
   before(() => {
     oauthConfig = {
-      realm: SERVICES_REALM,
       accessTokenEndpoint: oauthHost + '/access_token',
       tokenInfoEndpoint: oauthHost + '/tokeninfo',
       credentialsDir: 'integration-test/data/credentials',
@@ -36,7 +35,7 @@ describe('tokenCache', () => {
 
     // given
     nock(oauthHost)
-    .post('/access_token?realm=services')
+    .post('/access_token')
     .reply(HttpStatus.INTERNAL_SERVER_ERROR);
 
     // when
@@ -55,7 +54,7 @@ describe('tokenCache', () => {
     const accessToken = '4b70510f-be1d-4f0f-b4cb-edbca2c79d41';
 
     nock(oauthHost)
-    .post('/access_token?realm=/services')
+    .post('/access_token')
     .reply(HttpStatus.OK, {
       access_token: accessToken
     })
@@ -63,7 +62,6 @@ describe('tokenCache', () => {
     .reply(HttpStatus.OK, {
       'expires_in': 3600,
       'token_type': 'Bearer',
-      'realm': 'employees',
       'scope': ['nucleus.write', 'nucleus.read'],
       'grant_type': PASSWORD_CREDENTIALS_GRANT,
       'uid': 'uid',
@@ -93,7 +91,6 @@ describe('tokenCache', () => {
     const tokeninfo = {
       'expires_in': 3600,
       'token_type': 'Bearer',
-      'realm': 'employees',
       'scope': ['nucleus.write', 'nucleus.read'],
       'grant_type': PASSWORD_CREDENTIALS_GRANT,
       'uid': 'uid',
@@ -101,7 +98,7 @@ describe('tokenCache', () => {
     };
 
     nock(oauthHost)
-    .post('/access_token?realm=/services')
+    .post('/access_token')
     .reply(HttpStatus.OK, {
       access_token: accessToken
     })
@@ -136,7 +133,7 @@ describe('tokenCache', () => {
     const secondAccessToken = '9sdf8fd8-be1d-4f0f-b4cb-54nk66n45knk';
 
     nock(oauthHost)
-    .post('/access_token?realm=/services')
+    .post('/access_token')
     .reply(HttpStatus.OK, {
       access_token: firstAccessToken
     })
@@ -145,13 +142,12 @@ describe('tokenCache', () => {
       // make the first access token expire immediately
       'expires_in': 1,
       'token_type': 'Bearer',
-      'realm': 'employees',
       'scope': ['nucleus.write', 'nucleus.read'],
       'grant_type': PASSWORD_CREDENTIALS_GRANT,
       'uid': 'uid',
       'access_token': firstAccessToken
     })
-    .post('/access_token?realm=/services')
+    .post('/access_token')
     .reply(HttpStatus.OK, {
       access_token: secondAccessToken
     })
@@ -159,7 +155,6 @@ describe('tokenCache', () => {
     .reply(HttpStatus.OK, {
       'expires_in': 3600,
       'token_type': 'Bearer',
-      'realm': 'employees',
       'scope': ['nucleus.write', 'nucleus.read'],
       'grant_type': PASSWORD_CREDENTIALS_GRANT,
       'uid': 'uid',
@@ -193,7 +188,7 @@ describe('tokenCache', () => {
     const secondAccessToken = '9sdf8fd8-be1d-4f0f-b4cb-54nk66n45knk';
 
     nock(oauthHost)
-    .post('/access_token?realm=/services')
+    .post('/access_token')
     .reply(HttpStatus.OK, {
       access_token: firstAccessToken
     })
@@ -201,7 +196,6 @@ describe('tokenCache', () => {
     .reply(HttpStatus.OK, {
       'expires_in': 3600,
       'token_type': 'Bearer',
-      'realm': 'employees',
       'scope': ['nucleus.write', 'nucleus.read'],
       'grant_type': PASSWORD_CREDENTIALS_GRANT,
       'uid': 'uid',
@@ -212,7 +206,7 @@ describe('tokenCache', () => {
       error: 'invalid_request',
       error_description: 'Access token not valid'
     })
-    .post('/access_token?realm=/services')
+    .post('/access_token')
     .reply(HttpStatus.OK, {
       access_token: secondAccessToken
     })
@@ -220,7 +214,6 @@ describe('tokenCache', () => {
     .reply(HttpStatus.OK, {
       'expires_in': 3600,
       'token_type': 'Bearer',
-      'realm': 'employees',
       'scope': ['nucleus.write', 'nucleus.read'],
       'grant_type': PASSWORD_CREDENTIALS_GRANT,
       'uid': 'uid',
@@ -253,7 +246,7 @@ describe('tokenCache', () => {
     const secondAccessToken = '9sdf8fd8-be1d-4f0f-b4cb-54nk66n45knk';
 
     nock(oauthHost)
-    .post('/access_token?realm=/services')
+    .post('/access_token')
     .reply(HttpStatus.OK, {
       access_token: firstAccessToken
     })
@@ -261,13 +254,12 @@ describe('tokenCache', () => {
     .reply(HttpStatus.OK, {
       'expires_in': 3600,
       'token_type': 'Bearer',
-      'realm': 'employees',
       'scope': ['nucleus.write', 'nucleus.read'],
       'grant_type': PASSWORD_CREDENTIALS_GRANT,
       'uid': 'uid',
       'access_token': firstAccessToken
     })
-    .post('/access_token?realm=/services')
+    .post('/access_token')
     .reply(HttpStatus.OK, {
       access_token: secondAccessToken
     })
@@ -275,7 +267,6 @@ describe('tokenCache', () => {
     .reply(HttpStatus.OK, {
       'expires_in': 3600,
       'token_type': 'Bearer',
-      'realm': 'employees',
       'scope': ['nucleus.write', 'nucleus.read'],
       'grant_type': PASSWORD_CREDENTIALS_GRANT,
       'uid': 'uid',
@@ -309,7 +300,7 @@ describe('tokenCache', () => {
     const secondAccessToken = '9sdf8fd8-be1d-4f0f-b4cb-54nk66n45knk';
 
     nock(oauthHost)
-    .post('/access_token?realm=/services', function (body: any) {
+    .post('/access_token', function (body: any) {
       return body.scope === 'nucleus.write nucleus.read';
     })
     .reply(HttpStatus.OK, {
@@ -319,13 +310,12 @@ describe('tokenCache', () => {
     .reply(HttpStatus.OK, {
       'expires_in': 3600,
       'token_type': 'Bearer',
-      'realm': 'employees',
       'scope': ['nucleus.write', 'nucleus.read'],
       'grant_type': PASSWORD_CREDENTIALS_GRANT,
       'uid': 'uid',
       'access_token': firstAccessToken
     })
-    .post('/access_token?realm=/services', function (body: any) {
+    .post('/access_token', function (body: any) {
       return body.scope === 'all';
     })
     .reply(HttpStatus.OK, {
@@ -335,7 +325,6 @@ describe('tokenCache', () => {
     .reply(HttpStatus.OK, {
       'expires_in': 3600,
       'token_type': 'Bearer',
-      'realm': 'employees',
       'scope': ['all'],
       'grant_type': PASSWORD_CREDENTIALS_GRANT,
       'uid': 'uid',

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "lib-oauth-tooling",
-  "version": "1.1.1",
+  "version": "2.0.0",
   "description": "A simple typescript based oauth tooling library",
   "main": "./lib/src/index.js",
   "typings": "./lib/src/index.d.ts",

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -1,5 +1,3 @@
 export const AUTHORIZATION_CODE_GRANT = 'authorization_code';
 export const PASSWORD_CREDENTIALS_GRANT = 'password';
 export const REFRESH_TOKEN_GRANT = 'refresh_token';
-export const SERVICES_REALM = '/services';
-export const EMPLOYEES_REALM = '/employees';

--- a/src/oauth-tooling.ts
+++ b/src/oauth-tooling.ts
@@ -10,11 +10,11 @@ import {
 } from './utils';
 
 import {
-  EMPLOYEES_REALM,
   AUTHORIZATION_CODE_GRANT,
   PASSWORD_CREDENTIALS_GRANT,
   REFRESH_TOKEN_GRANT
 } from './constants';
+
 import { OAuthConfig } from './types/OAuthConfig';
 import { Token } from './types/Token';
 import { TokenInfo } from './types/TokenInfo';
@@ -40,7 +40,6 @@ function createAuthCodeRequestUri(authorizationEndpoint: string, clientId: strin
     'client_id': clientId,
     'redirect_uri': redirectUri,
     'response_type': 'code',
-    'realm': EMPLOYEES_REALM,
     ...queryParams
   };
 
@@ -59,22 +58,17 @@ function createAuthCodeRequestUri(authorizationEndpoint: string, clientId: strin
  * @param bodyObject an object of values put in the body
  * @param authorizationHeaderValue
  * @param accessTokenEndpoint
- * @param realm
  * @param queryParams optional
  * @returns {Promise<T>|Q.Promise<U>}
  */
 function requestAccessToken(bodyObject: any, authorizationHeaderValue: string,
-                            accessTokenEndpoint: string, realm: string,
-                            queryParams?: {}): Promise<Token> {
+                            accessTokenEndpoint: string, queryParams?: Object): Promise<Token> {
 
   const promise = new Promise(function(resolve, reject) {
 
-    const queryString = qs.stringify({ realm, ...queryParams });
+    const url = buildRequestAccessTokenUrl(accessTokenEndpoint, queryParams);
 
-    // we are unescaping again since we did not escape before using querystring and we do not want to break anything
-    const unescapedQueryString = qs.unescape(queryString);
-
-    fetch(`${accessTokenEndpoint}?${unescapedQueryString}`, {
+    fetch(url, {
       method: 'POST',
       body: formurlencoded(bodyObject),
       headers: {
@@ -106,6 +100,27 @@ function requestAccessToken(bodyObject: any, authorizationHeaderValue: string,
   });
 
   return promise;
+}
+
+/**
+ * Build url string to request access token, optionally with given query parameters.
+ *
+ * @param accessTokenEndpoint
+ * @param queryParams
+ * @returns {string}
+ */
+function buildRequestAccessTokenUrl(accessTokenEndpoint: string, queryParams?: Object): string {
+
+  if (queryParams !== undefined) {
+    const queryString = qs.stringify(queryParams);
+
+    // we are unescaping again since we did not escape before using querystring and we do not want to break anything
+    const unescapedQueryString = qs.unescape(queryString);
+
+    return `${accessTokenEndpoint}?${unescapedQueryString}`;
+  } else {
+    return accessTokenEndpoint;
+  }
 }
 
 /**
@@ -165,7 +180,6 @@ function getTokenInfo(tokenInfoUrl: string, accessToken: string): Promise<TokenI
  *  - credentialsDir string
  *  - grantType string
  *  - accessTokenEndpoint string
- *  - realm string
  *  - scopes string optional
  *  - queryParams {} optional
  *  - redirect_uri string optional (required with AUTHORIZATION_CODE_GRANT)
@@ -220,7 +234,7 @@ function getAccessToken(options: OAuthConfig): Promise<Token> {
     const authorizationHeaderValue = getBasicAuthHeaderValue(clientData.client_id, clientData.client_secret);
 
     return requestAccessToken(bodyParameters, authorizationHeaderValue,
-      options.accessTokenEndpoint, options.realm, options.queryParams);
+      options.accessTokenEndpoint, options.queryParams);
   });
 }
 

--- a/src/oauth-tooling.ts
+++ b/src/oauth-tooling.ts
@@ -105,8 +105,8 @@ function requestAccessToken(bodyObject: any, authorizationHeaderValue: string,
 /**
  * Build url string to request access token, optionally with given query parameters.
  *
- * @param accessTokenEndpoint
- * @param queryParams
+ * @param accessTokenEndpoint string
+ * @param queryParams Object key value paris which will be added as query parameters
  * @returns {string}
  */
 function buildRequestAccessTokenUrl(accessTokenEndpoint: string, queryParams?: Object): string {

--- a/src/types/OAuthConfig.ts
+++ b/src/types/OAuthConfig.ts
@@ -3,7 +3,6 @@ interface OAuthConfig {
   grantType: string; // (`AUTHORIZATION_CODE_GRANT` | `PASSWORD_CREDENTIALS_GRANT`)
   accessTokenEndpoint: string;
   tokenInfoEndpoint?: string; // mandatory for TokenCache
-  realm: string; // (`SERVICES_REALM` | `EMPLOYEES_REALM`)
   scopes?: string[];
   redirect_uri?: string; // (required with `AUTHORIZATION_CODE_GRANT`)
   code?: string; // (required with `AUTHORIZATION_CODE_GRANT`)

--- a/src/types/Token.ts
+++ b/src/types/Token.ts
@@ -2,7 +2,6 @@ interface Token {
   access_token: string;
   expires_in: number;
   id_token: string;
-  realm: string;
   scope: string;
   token_type: string;
 }

--- a/src/types/TokenInfo.ts
+++ b/src/types/TokenInfo.ts
@@ -4,7 +4,6 @@ interface TokenInfo {
   expires_in: number;
   grant_type?: string;
   open_id?: string;
-  realm?: String;
   scope: String[];
   token_type?: string;
   uid?: string;

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -151,10 +151,6 @@ export function validateOAuthConfig(options: OAuthConfig) {
     throw TypeError('accessTokenEndpoint must be defined');
   }
 
-  if (!options.realm) {
-    throw TypeError('realm must be defined');
-  }
-
   if (!options.grantType) {
     throw TypeError('grantType must be defined');
   }

--- a/test/unit/index.ts
+++ b/test/unit/index.ts
@@ -5,8 +5,6 @@ import {
   TokenCache,
   getAccessToken,
   createAuthCodeRequestUri,
-  SERVICES_REALM,
-  EMPLOYEES_REALM,
   AUTHORIZATION_CODE_GRANT,
   PASSWORD_CREDENTIALS_GRANT,
   REFRESH_TOKEN_GRANT
@@ -20,7 +18,6 @@ describe('oauth tooling', () => {
   describe('getAccessToken should throw TypeError', () => {
 
     const config = {
-      realm: SERVICES_REALM,
       accessTokenEndpoint: '/oauth2/access_token',
       credentialsDir: 'credentials',
       grantType: AUTHORIZATION_CODE_GRANT,
@@ -46,13 +43,6 @@ describe('oauth tooling', () => {
       expect(getAccessToken.bind(undefined, {
         ...config,
         grantType: undefined
-      })).to.throw(TypeError);
-    });
-
-    it('if realm is not defined', () => {
-      expect(getAccessToken.bind(undefined, {
-        ...config,
-        realm: undefined
       })).to.throw(TypeError);
     });
 
@@ -95,8 +85,7 @@ describe('oauth tooling', () => {
       const expected = `${authorizationEndpoint}` +
         `?client_id=${clientId}` +
         `&redirect_uri=${redirectUri}` +
-        `&response_type=code` +
-        `&realm=${EMPLOYEES_REALM}`;
+        `&response_type=code`;
 
       expect(result).to.equal(expected);
     });
@@ -120,7 +109,6 @@ describe('oauth tooling', () => {
         `?client_id=${clientId}` +
         `&redirect_uri=${redirectUri}` +
         `&response_type=code` +
-        `&realm=${EMPLOYEES_REALM}` +
         `&foo=bar`;
 
       expect(result).to.equal(expected);
@@ -135,7 +123,6 @@ describe('oauth tooling', () => {
         return new TokenCache({
           'foo': ['uid']
         }, {
-          realm: SERVICES_REALM,
           accessTokenEndpoint: '/access_token',
           credentialsDir: '/credentials',
           grantType: PASSWORD_CREDENTIALS_GRANT
@@ -148,7 +135,6 @@ describe('oauth tooling', () => {
       const tokenCache = new TokenCache({
         'foo': ['uid']
       }, {
-        realm: SERVICES_REALM,
         accessTokenEndpoint: '/access_token',
         tokenInfoEndpoint: '/tokeninfo',
         credentialsDir: '/credentials',


### PR DESCRIPTION
The (zalando-specific) `realm` property was removed from `OAuthConfig`.
Also, the corresponding constants (`SERVICES_REALM` and
`EMPLYEES_REALM`) were removed. Instead, you can add the realm (and
arbitrary other query parameters) via the `queryParams` property in
`OAuthConfig`.

close #40