### PR TITLE
feat(express-tooling): make publicPath optional

### DIFF
--- a/integration-test/oauth-tooling/middlewares.spec.ts
+++ b/integration-test/oauth-tooling/middlewares.spec.ts
@@ -122,10 +122,7 @@ describe('middlewares', () => {
 
     // when
     const promise = fetch('http://127.0.0.1:30002/resource/user')
-    .then((res) => {
-
-      return res.status;
-    });
+    .then(res => res.status);
 
     // then
     return expect(promise).to.become(HttpStatus.UNAUTHORIZED);
@@ -144,10 +141,7 @@ describe('middlewares', () => {
         authorization: authHeader
       }
     })
-    .then((res) => {
-
-      return res.status;
-    });
+    .then(res => res.status);
 
     // then
     return expect(promise).to.become(HttpStatus.UNAUTHORIZED);

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "lib-oauth-tooling",
-  "version": "2.1.0",
+  "version": "2.2.0",
   "description": "A simple typescript based oauth tooling library",
   "main": "./lib/src/index.js",
   "typings": "./lib/src/index.d.ts",
@@ -8,6 +8,10 @@
   "keywords": [
     "zalando",
     "oauth2",
+    "express",
+    "node",
+    "service",
+    "rest",
     "typescript"
   ],
   "publishConfig": {
@@ -34,7 +38,7 @@
   },
   "devDependencies": {
     "@types/body-parser": "1.16.3",
-    "@types/chai": "3.5.1",
+    "@types/chai": "3.5.2",
     "@types/chai-as-promised": "0.0.30",
     "@types/express": "4.0.35",
     "@types/http-status": "0.2.29",
@@ -46,10 +50,10 @@
     "chai": "3.5.0",
     "chai-as-promised": "6.0.0",
     "express": "4.15.2",
-    "mocha": "3.2.0",
-    "nyc":"10.2.0",
+    "mocha": "3.3.0",
+    "nyc":"10.3.2",
     "tslint": "4.5.1",
-    "typescript": "2.2.2"
+    "typescript": "2.3.2"
   },
   "scripts": {
     "test": "npm run build && mocha lib/test lib/integration-test --recursive",

--- a/src/types/MiddlewareOptions.ts
+++ b/src/types/MiddlewareOptions.ts
@@ -1,5 +1,5 @@
 interface MiddlewareOptions {
-  publicEndpoints: string[];
+  publicEndpoints?: string[];
   tokenInfoEndpoint: string;
 }
 

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -32,35 +32,16 @@ export function getFileData(filePath: string, fileName: string): q.Promise<any> 
 }
 
 /**
- * Checks whether a given url matches one of a set of given patterns.
- *
- * @param url
- * @param patterns
- * @returns {boolean}
- */
-export function match(url: string, patterns: Set<string>): boolean {
-
-  let isPatternMatch: boolean = false;
-
-  patterns.forEach((pattern) => {
-    if (url.startsWith(pattern)) {
-      isPatternMatch = true;
-    }
-  });
-
-  return isPatternMatch;
-}
-
-/**
  * Returns the value of a specified header field from a request
  *
  * @param req
  * @param field The name of the field to return
  * @returns {string} The value of the header field
  */
-export function getHeaderValue(req: express.Request, field: string): string {
-  if (req && field && req.headers.hasOwnProperty(field)) {
-    return req.headers[field];
+export function getHeaderValue(req: express.Request, fieldName: string): string {
+
+  if (req && fieldName && req.headers.hasOwnProperty(fieldName)) {
+    return req.headers[fieldName];
   } else {
     return '';
   }
@@ -91,7 +72,7 @@ export function extractAccessToken(authHeader: string): string {
   if (parts[0] === AUTHORIZATION_BEARER_PREFIX && parts.length === 2) {
     return parts[1];
   } else {
-    return undefined;
+    return;
   }
 }
 

--- a/test/unit/express-tooling.ts
+++ b/test/unit/express-tooling.ts
@@ -226,12 +226,14 @@ describe('oauth tooling', () => {
       const next = () => {
         called = true;
       };
-
-      // when
-      handleOAuthRequestMiddleware({
+      const config = {
         publicEndpoints: [ '/public', '/healthcheck' ],
         tokenInfoEndpoint: '/oauth2/tokeninfo'
-      })({ 'originalUrl': '/healthcheck' }, responseMock, next);
+      };
+      const _requestMock = { originalUrl: '/healthcheck' };
+
+      // when
+      handleOAuthRequestMiddleware(config)(_requestMock, responseMock, next);
 
       // then
       return expect(called).to.be.true;
@@ -244,12 +246,14 @@ describe('oauth tooling', () => {
       const next = () => {
         called = true;
       };
-
-      // when
-      handleOAuthRequestMiddleware({
+      const config = {
         publicEndpoints: [ '/public', '/healthcheck' ],
         tokenInfoEndpoint: '/oauth2/tokeninfo'
-      })({ 'originalUrl': '/privateAPI', headers: {} }, responseMock, next);
+      };
+      const _requestMock = { originalUrl: '/privateAPI', headers: {} };
+
+      // when
+      handleOAuthRequestMiddleware(config)(_requestMock, responseMock, next);
 
       // then
       return expect(called).to.be.false;


### PR DESCRIPTION
- removed util method match as it's body was as long as it's call signature

close #51